### PR TITLE
fix(linkedin): fix broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ layout: default
       </span>
     </a>
   
-    <a href="www.linkedin.com/in/alyfluckey" target="_blank">
+    <a href="https://www.linkedin.com/in/alyfluckey" target="_blank">
       <span class="icon tooltip" data-tooltip="Follow me!">
         {% include linkedin.svg %}
       </span>


### PR DESCRIPTION
LinkedIn link was broken - needs the `https`

![giphy-1](https://github.com/wtfluckey/wtfluckey.com/assets/2893463/31c35059-0fbc-4073-a1e5-fc673922c0d5)
