### PR TITLE
(performance): only animate when in view

### DIFF
--- a/index.css
+++ b/index.css
@@ -478,11 +478,11 @@ a {
   height: 4rem;
   background: linear-gradient(to bottom, transparent, var(--text-secondary));
   animation: scrollPulse 2.2s var(--ease-out) infinite;
-  animation-play-state: running;
+  animation-play-state: paused;
 }
 
-.hero__scroll-line.paused {
-  animation-play-state: paused;
+.hero__scroll-line.playing {
+  animation-play-state: running;
 }
 
 @keyframes scrollPulse {

--- a/index.css
+++ b/index.css
@@ -478,6 +478,11 @@ a {
   height: 4rem;
   background: linear-gradient(to bottom, transparent, var(--text-secondary));
   animation: scrollPulse 2.2s var(--ease-out) infinite;
+  animation-play-state: running;
+}
+
+.hero__scroll-line.paused {
+  animation-play-state: paused;
 }
 
 @keyframes scrollPulse {
@@ -950,6 +955,11 @@ a {
   user-select: none;
   opacity: 0.6;
   animation: glyphSpin 18s linear infinite;
+  animation-play-state: paused;
+}
+
+.lets-talk__glyph.spinning {
+  animation-play-state: running;
 }
 
 @keyframes glyphSpin {
@@ -962,7 +972,8 @@ a {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .lets-talk__glyph {
+  .lets-talk__glyph,
+  .lets-talk__glyph.spinning {
     animation: none;
   }
 }
@@ -1081,6 +1092,12 @@ a {
 ============================================================ */
 
 @media (max-width: 767px) {
+  .nav {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: rgba(8, 8, 24, 0.96);
+  }
+
   .hero {
     padding-top: 5rem;
     padding-bottom: var(--space-lg);

--- a/index.js
+++ b/index.js
@@ -332,6 +332,50 @@
   }
 
   /* ============================================================
+     ANIMATIONS — pause/resume infinite animations based on visibility
+  ============================================================ */
+
+  function initAnimations() {
+    if (!("IntersectionObserver" in window)) return;
+
+    // scrollPulse — pause when hero scrolls out of view
+    var scrollLine = $(".hero__scroll-line");
+    if (scrollLine) {
+      var scrollObserver = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              scrollLine.classList.remove("paused");
+            } else {
+              scrollLine.classList.add("paused");
+            }
+          });
+        },
+        { threshold: 0 },
+      );
+      scrollObserver.observe(scrollLine);
+    }
+
+    // glyphSpin — only run when the glyph is visible
+    var glyph = $(".lets-talk__glyph");
+    if (glyph) {
+      var glyphObserver = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              glyph.classList.add("spinning");
+            } else {
+              glyph.classList.remove("spinning");
+            }
+          });
+        },
+        { threshold: 0 },
+      );
+      glyphObserver.observe(glyph);
+    }
+  }
+
+  /* ============================================================
      INIT
   ============================================================ */
 
@@ -341,6 +385,7 @@
     initRainbow();
     initScrollReveal();
     initStagger();
+    initAnimations();
   }
 
   if (document.readyState === "loading") {

--- a/index.js
+++ b/index.js
@@ -338,41 +338,24 @@
   function initAnimations() {
     if (!("IntersectionObserver" in window)) return;
 
-    // scrollPulse — pause when hero scrolls out of view
-    var scrollLine = $(".hero__scroll-line");
-    if (scrollLine) {
-      var scrollObserver = new IntersectionObserver(
+    // Adds className when el enters the viewport, removes it when it leaves.
+    function observeVisibility(el, className) {
+      if (!el) return;
+      new IntersectionObserver(
         function (entries) {
           entries.forEach(function (entry) {
-            if (entry.isIntersecting) {
-              scrollLine.classList.remove("paused");
-            } else {
-              scrollLine.classList.add("paused");
-            }
+            el.classList.toggle(className, entry.isIntersecting);
           });
         },
         { threshold: 0 },
-      );
-      scrollObserver.observe(scrollLine);
+      ).observe(el);
     }
 
+    // scrollPulse — only animate when the scroll hint is visible
+    observeVisibility($(".hero__scroll-line"), "playing");
+
     // glyphSpin — only run when the glyph is visible
-    var glyph = $(".lets-talk__glyph");
-    if (glyph) {
-      var glyphObserver = new IntersectionObserver(
-        function (entries) {
-          entries.forEach(function (entry) {
-            if (entry.isIntersecting) {
-              glyph.classList.add("spinning");
-            } else {
-              glyph.classList.remove("spinning");
-            }
-          });
-        },
-        { threshold: 0 },
-      );
-      glyphObserver.observe(glyph);
-    }
+    observeVisibility($(".lets-talk__glyph"), "spinning");
   }
 
   /* ============================================================


### PR DESCRIPTION
To improve performance on mobile (phone was getting hot 🔥):

- only run CSS animations when the elements are in view
- remove `backdrop-filter` in the nav on mobile.