### PR TITLE
(fix): styleguide link

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,8 +77,6 @@
             </div>
           </div>
         </div>
-
-
       </section>
 
       <section
@@ -170,12 +168,8 @@
                 aria-controls="cs-lists-body"
               >
                 <div class="accordion__meta">
-                  <span class="section__eyebrow"
-                    >Mozilla Pocket</span
-                  >
-                  <span class="badge"
-                    >Cross-Functional Leadership</span
-                  >
+                  <span class="section__eyebrow">Mozilla Pocket</span>
+                  <span class="badge">Cross-Functional Leadership</span>
                 </div>
                 <h3 class="accordion__title">Pocket Lists — Feature Launch</h3>
                 <p class="accordion__teaser text--body">
@@ -188,9 +182,7 @@
               <div class="accordion__body" id="cs-lists-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Context
-                    </h4>
+                    <h4 class="text--overline">Context</h4>
                     <p>
                       Pocket's core save-and-read loop was strong, but user
                       organization features had stagnated. Lists represented a
@@ -217,9 +209,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Who I Worked With
-                    </h4>
+                    <h4 class="text--overline">Who I Worked With</h4>
                     <p>
                       Frontend engineers, backend engineers, a product manager,
                       UX designer, QA engineers, and the data team. Stakeholder
@@ -227,9 +217,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Led
-                    </h4>
+                    <h4 class="text--overline">What I Led</h4>
                     <ul class="arrow-list">
                       <li>Owned planning, sequencing, and delivery tracking</li>
                       <li>
@@ -246,9 +234,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Results
-                    </h4>
+                    <h4 class="text--overline">Results</h4>
                     <ul class="arrow-list">
                       <li>Feature shipped on target timeline</li>
                       <li>
@@ -261,9 +247,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Learned
-                    </h4>
+                    <h4 class="text--overline">What I Learned</h4>
                     <p>
                       Sequencing is often more valuable than speed. Getting the
                       order of work right — and making that order visible to
@@ -283,12 +267,8 @@
                 aria-controls="cs-design-system-body"
               >
                 <div class="accordion__meta">
-                  <span class="section__eyebrow"
-                    >Mozilla Pocket</span
-                  >
-                  <span class="badge"
-                    >Frontend Systems</span
-                  >
+                  <span class="section__eyebrow">Mozilla Pocket</span>
+                  <span class="badge">Frontend Systems</span>
                 </div>
                 <h3 class="accordion__title">
                   Card Anatomy & Design System Modernization
@@ -304,9 +284,7 @@
               <div class="accordion__body" id="cs-design-system-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Context
-                    </h4>
+                    <h4 class="text--overline">Context</h4>
                     <p>
                       Pocket's card components — the core UI unit across the
                       product — had accumulated significant inconsistency and
@@ -324,9 +302,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Who I Worked With
-                    </h4>
+                    <h4 class="text--overline">Who I Worked With</h4>
                     <p>
                       Frontend engineers across multiple teams, the design
                       system team, and UX designers. Required alignment with
@@ -335,9 +311,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Led
-                    </h4>
+                    <h4 class="text--overline">What I Led</h4>
                     <ul class="arrow-list">
                       <li>
                         Built the case for prioritizing design system work
@@ -354,9 +328,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Results
-                    </h4>
+                    <h4 class="text--overline">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         Significantly reduced UI inconsistency across the
@@ -372,9 +344,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Learned
-                    </h4>
+                    <h4 class="text--overline">What I Learned</h4>
                     <p>
                       Infrastructure work lives or dies on stakeholder buy-in.
                       Framing system improvements in terms of future feature
@@ -394,12 +364,8 @@
                 aria-controls="cs-experiments-body"
               >
                 <div class="accordion__meta">
-                  <span class="section__eyebrow"
-                    >Mozilla Pocket</span
-                  >
-                  <span class="badge"
-                    >Experimentation & Analytics</span
-                  >
+                  <span class="section__eyebrow">Mozilla Pocket</span>
+                  <span class="badge">Experimentation & Analytics</span>
                 </div>
                 <h3 class="accordion__title">
                   A/B Testing & Experimentation Enablement
@@ -414,9 +380,7 @@
               <div class="accordion__body" id="cs-experiments-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Context
-                    </h4>
+                    <h4 class="text--overline">Context</h4>
                     <p>
                       Product teams wanted to test more, but the experimentation
                       infrastructure was inconsistent and the process for
@@ -439,9 +403,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Who I Worked With
-                    </h4>
+                    <h4 class="text--overline">Who I Worked With</h4>
                     <p>
                       Data engineers, product managers, frontend engineers, and
                       QA. Close collaboration with analytics to ensure
@@ -449,9 +411,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Led
-                    </h4>
+                    <h4 class="text--overline">What I Led</h4>
                     <ul class="arrow-list">
                       <li>Defined experiment design and review standards</li>
                       <li>
@@ -467,9 +427,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Results
-                    </h4>
+                    <h4 class="text--overline">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         Teams moved from ad hoc testing to structured
@@ -486,9 +444,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Learned
-                    </h4>
+                    <h4 class="text--overline">What I Learned</h4>
                     <p>
                       Experimentation is as much a cultural shift as a technical
                       one. Getting teams to slow down enough to design a good
@@ -508,12 +464,8 @@
                 aria-controls="cs-social-body"
               >
                 <div class="accordion__meta">
-                  <span class="section__eyebrow"
-                    >Mozilla Social</span
-                  >
-                  <span class="badge"
-                    >Analytics · Invite Systems</span
-                  >
+                  <span class="section__eyebrow">Mozilla Social</span>
+                  <span class="badge">Analytics · Invite Systems</span>
                 </div>
                 <h3 class="accordion__title">
                   Mozilla Social — Analytics & Invite Flow
@@ -528,9 +480,7 @@
               <div class="accordion__body" id="cs-social-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Context
-                    </h4>
+                    <h4 class="text--overline">Context</h4>
                     <p>
                       Mozilla launched a Mastodon-based social instance during
                       the broader Fediverse growth period. As a new product with
@@ -557,9 +507,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Who I Worked With
-                    </h4>
+                    <h4 class="text--overline">Who I Worked With</h4>
                     <p>
                       Small, cross-functional team including product,
                       engineering, and trust & safety. Close alignment with
@@ -567,9 +515,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Led
-                    </h4>
+                    <h4 class="text--overline">What I Led</h4>
                     <ul class="arrow-list">
                       <li>Designed and owned the invite flow architecture</li>
                       <li>Built out analytics instrumentation from scratch</li>
@@ -583,9 +529,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Results
-                    </h4>
+                    <h4 class="text--overline">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         Invite system launched with controlled onboarding that
@@ -602,9 +546,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Learned
-                    </h4>
+                    <h4 class="text--overline">What I Learned</h4>
                     <p>
                       Launching a new product — even inside a large org —
                       requires treating ambiguity as the default state and
@@ -625,12 +567,8 @@
                 aria-controls="cs-consulting-body"
               >
                 <div class="accordion__meta">
-                  <span class="section__eyebrow"
-                    >Consulting</span
-                  >
-                  <span class="badge"
-                    >Architecture · Internationalization</span
-                  >
+                  <span class="section__eyebrow">Consulting</span>
+                  <span class="badge">Architecture · Internationalization</span>
                 </div>
                 <h3 class="accordion__title">
                   Multilingual Architecture in Webflow
@@ -645,9 +583,7 @@
               <div class="accordion__body" id="cs-consulting-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Context
-                    </h4>
+                    <h4 class="text--overline">Context</h4>
                     <p>
                       A client needed to expand their Webflow-based site to
                       support multiple language markets — without rebuilding
@@ -671,9 +607,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Who I Worked With
-                    </h4>
+                    <h4 class="text--overline">Who I Worked With</h4>
                     <p>
                       Client stakeholders, content editors, and a small
                       development team. Required close collaboration with
@@ -682,9 +616,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Led
-                    </h4>
+                    <h4 class="text--overline">What I Led</h4>
                     <ul class="arrow-list">
                       <li>
                         Designed the content architecture and routing strategy
@@ -701,9 +633,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      Results
-                    </h4>
+                    <h4 class="text--overline">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         Multilingual content delivery live across target markets
@@ -716,9 +646,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">
-                      What I Learned
-                    </h4>
+                    <h4 class="text--overline">What I Learned</h4>
                     <p>
                       Constraints imposed by platform limitations often force
                       more creative, maintainable solutions than a greenfield
@@ -855,7 +783,10 @@
 
         <div class="footer__bottom">
           <span class="footer__copy">
-            Just HTML, CSS, and <a href="styleguide.html" class="footer__link--inline">strong opinions</a>.
+            Just HTML, CSS, and
+            <a href="/styleguide.html" class="footer__link--inline"
+              >strong opinions</a
+            >.
           </span>
           <button
             class="btn btn--sm btn--rainbow"


### PR DESCRIPTION
also some dumb spacing adjustments due to the linter

This is what shows when navigating to the styleguide in the footer.
<img width="526" height="243" alt="Screenshot 2026-02-20 at 10 31 28 PM" src="https://github.com/user-attachments/assets/b8e41d71-41c4-46db-ae70-8af6ed394763" />
