### PR TITLE
fix(cicd): deploy all HTML, CSS, and JS files to S3

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,17 +33,19 @@ jobs:
           aws s3 sync . s3://alyfluckey.com \
             --delete \
             --exclude "*" \
-            --include "index.html" \
-            --include "index.css" \
-            --include "index.js" \
+            --include "*.html" \
+            --include "*.css" \
+            --include "*.js" \
             --cache-control "public, max-age=3600, s-maxage=86400"
 
       - name: Set HTML cache headers
         run: |
-          aws s3 cp s3://alyfluckey.com/index.html s3://alyfluckey.com/index.html \
-            --metadata-directive REPLACE \
-            --content-type "text/html" \
-            --cache-control "public, max-age=0, must-revalidate, s-maxage=86400"
+          for file in $(aws s3 ls s3://alyfluckey.com/ --recursive | awk '{print $4}' | grep '\.html$'); do
+            aws s3 cp "s3://alyfluckey.com/$file" "s3://alyfluckey.com/$file" \
+              --metadata-directive REPLACE \
+              --content-type "text/html" \
+              --cache-control "public, max-age=0, must-revalidate, s-maxage=86400"
+          done
 
       - name: Invalidate CloudFront cache
         run: |


### PR DESCRIPTION
## Summary

- Switched S3 sync includes from hardcoded filenames (`index.html`, `index.css`, `index.js`) to glob patterns (`*.html`, `*.css`, `*.js`) so new files like `styleguide.html` are deployed automatically
- Updated the HTML cache header step to loop over all `.html` files in the bucket instead of only targeting `index.html`

## Test plan

- [ ] Merge and verify the deploy workflow runs successfully
- [ ] Confirm `styleguide.html` is accessible at the production URL without access denied errors
- [ ] Confirm `index.html` still has correct `must-revalidate` cache headers