### PR TITLE
refactor(CSS): typography audit and design system cleanup

### DIFF
--- a/index.css
+++ b/index.css
@@ -57,17 +57,13 @@
     --space-lg: 4rem; /* 64px */
     --space-xl: 8rem; /* 128px */
 
-    /* Font families */
-    --font-display: "Exo", sans-serif;
+    /* Font family — single token, Exo with system fallbacks */
     --font-body: "Exo", "Helvetica Neue", Helvetica, Arial, sans-serif;
 
     /* Font size scale */
-    --font-size-xs: 0.6875rem; /* 11px — tag labels, marker arrows */
-    --font-size-sm: 0.75rem; /* 12px — eyebrows, overlines, small labels */
-    --font-size-ui: 0.875rem; /* 14px — UI chrome: toggles, footer copy, links & tagline */
-    --font-size-base: 0.9375rem; /* 15px — primary body text */
-    --font-size-md: 1.0625rem; /* 17px — lead text, card body */
-    --font-size-lg: 1.125rem; /* 18px — component headings */
+    --font-size-sm: 0.75rem; /* 12px — labels, badges, eyebrows, arrows */
+    --font-size-base: 0.9375rem; /* 15px — body text, UI chrome */
+    --font-size-lg: 1.125rem; /* 18px — component headings, lead text */
     --font-size-xl: 1.375rem; /* 22px — nav wordmark, accordion title */
     --font-size-2xl: 1.75rem; /* 28px — footer name, card icon */
 
@@ -203,9 +199,18 @@
     color: var(--text-secondary);
   }
 
+  /* ----- Column label (accordion body col heading pattern) ----- */
+  .text--col-label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--weight-semibold);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--accent-pink);
+  }
+
   /* ----- Pill badge (category / tag label) ----- */
   .badge {
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-sm);
     font-weight: var(--weight-medium);
     letter-spacing: var(--tracking-wide);
     text-transform: uppercase;
@@ -251,11 +256,16 @@
     letter-spacing: var(--tracking-widest);
     text-transform: uppercase;
     color: var(--accent-cyan);
-    margin-bottom: 0.75rem;
   }
 
+  /* Margin-bottom utilities */
+  .mb--xs { margin-bottom: var(--space-xs); }
+  .mb--sm { margin-bottom: var(--space-sm); }
+  .mb--sm-plus { margin-bottom: var(--space-sm-plus); }
+  .mb--md { margin-bottom: var(--space-md); }
+
   .section__title {
-    font-family: var(--font-display);
+    font-family: var(--font-body);
     font-size: clamp(2rem, 5vw, 3.25rem);
     line-height: var(--leading-display);
     letter-spacing: var(--tracking-tight);
@@ -264,7 +274,7 @@
   }
 
   .section__subtitle {
-    font-size: var(--font-size-md);
+    font-size: var(--font-size-lg);
     color: var(--text-secondary);
     line-height: var(--leading-relaxed);
     margin-bottom: var(--space-sm-plus);
@@ -426,7 +436,7 @@
   }
 
   .btn__icon {
-    font-size: var(--font-size-ui);
+    font-size: var(--font-size-base);
     line-height: var(--leading-none);
     transition: transform var(--duration-medium) var(--ease-out);
   }
@@ -491,7 +501,7 @@
   }
 
   .nav__wordmark {
-    font-family: var(--font-display);
+    font-family: var(--font-body);
     font-size: var(--font-size-xl);
     letter-spacing: var(--tracking-tight);
     text-decoration: none;
@@ -562,7 +572,7 @@
 
   /* Big name */
   .hero__name {
-    font-family: var(--font-display);
+    font-family: var(--font-body);
     font-size: clamp(4rem, 13vw, 10rem);
     line-height: var(--leading-hero);
     letter-spacing: var(--tracking-tighter);
@@ -588,7 +598,7 @@
   }
 
   .hero__credibility {
-    font-size: var(--font-size-ui);
+    font-size: var(--font-size-base);
     color: var(--text-secondary);
     line-height: var(--leading-loose);
     margin-bottom: var(--space-sm-plus);
@@ -630,7 +640,7 @@
   }
 
   .card__title {
-    font-family: var(--font-display);
+    font-family: var(--font-body);
     font-size: var(--font-size-lg);
     letter-spacing: var(--tracking-normal);
     color: var(--text-primary);
@@ -701,7 +711,7 @@
 
   .accordion__title {
     grid-area: title;
-    font-family: var(--font-display);
+    font-family: var(--font-body);
     font-size: clamp(var(--font-size-lg), 2.5vw, var(--font-size-xl));
     font-weight: var(--weight-normal);
     letter-spacing: var(--tracking-normal);
@@ -778,25 +788,14 @@
     }
   }
 
-  .accordion__col h4 {
-    font-size: var(--font-size-xs);
-    letter-spacing: var(--tracking-wider);
-    color: var(--accent-pink);
-    margin-bottom: 0.65rem;
-  }
-
   .accordion__col p {
     color: var(--text-secondary);
     line-height: var(--leading-relaxed);
   }
 
-  /* ----- Technical Experience ----- */
+  /* ----- Badge Group ----- */
 
-  .tech__group .text--overline {
-    margin-bottom: var(--space-sm);
-  }
-
-  .tech__chips {
+  .badge-group__chips {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-xs);
@@ -880,14 +879,14 @@
   }
 
   .footer__name {
-    font-family: var(--font-display);
+    font-family: var(--font-body);
     font-size: var(--font-size-2xl);
     letter-spacing: var(--tracking-tight);
     margin-bottom: var(--space-xs);
   }
 
   .footer__tagline {
-    font-size: var(--font-size-ui);
+    font-size: var(--font-size-base);
     color: var(--text-secondary);
     line-height: var(--leading-snug);
   }
@@ -903,7 +902,7 @@
     display: inline-flex;
     align-items: center;
     gap: var(--space-xs);
-    font-size: var(--font-size-ui);
+    font-size: var(--font-size-base);
     color: var(--text-secondary);
     transition: color var(--duration);
   }
@@ -930,7 +929,7 @@
   }
 
   .footer__copy {
-    font-size: var(--font-size-ui);
+    font-size: var(--font-size-base);
     color: var(--text-secondary);
   }
 

--- a/index.css
+++ b/index.css
@@ -707,16 +707,8 @@
     letter-spacing: var(--tracking-normal);
     color: var(--text-primary);
     line-height: var(--leading-tight);
-    transition: color var(--duration);
   }
 
-  .accordion__trigger:hover .accordion__title,
-  .accordion__item.is-open .accordion__title {
-    background-image: var(--gradient);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-  }
 
   .accordion__teaser {
     grid-area: teaser;

--- a/index.css
+++ b/index.css
@@ -369,6 +369,11 @@
     transition: opacity var(--duration) var(--ease-out);
   }
 
+  .btn:hover,
+  .btn:focus-visible {
+    transform: translateY(-2px);
+  }
+
   .btn--primary:hover::before,
   .btn--primary:focus-visible::before {
     opacity: 1;
@@ -376,7 +381,6 @@
 
   .btn--primary:hover,
   .btn--primary:focus-visible {
-    transform: translateY(-2px);
     box-shadow: 0 6px 28px var(--accent-glow);
   }
 
@@ -384,13 +388,15 @@
     border: var(--border-width) solid var(--border-subtle);
     color: var(--text-secondary);
     background: transparent;
+    transition:
+      border-color var(--duration),
+      color var(--duration);
   }
 
   .btn--ghost:hover,
   .btn--ghost:focus-visible {
     border-color: var(--border-hover);
     color: var(--text-primary);
-    transform: translateY(-2px);
   }
 
   /* ----- Button size modifiers ----- */
@@ -474,7 +480,9 @@
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-bottom: var(--border-width) solid transparent;
-    transition: border-color var(--duration);
+    transition:
+      border-color var(--duration),
+      box-shadow var(--duration) var(--ease-out);
   }
 
   .nav.scrolled {

--- a/index.css
+++ b/index.css
@@ -186,13 +186,6 @@
     text-transform: uppercase;
   }
 
-  /* ----- Medium uppercase label (tag / subtitle pattern) ----- */
-  .text--tag {
-    font-weight: var(--weight-medium);
-    letter-spacing: var(--tracking-wide);
-    text-transform: uppercase;
-  }
-
   /* ----- Primary body text ----- */
   .text--body {
     font-size: var(--font-size-base);
@@ -259,10 +252,18 @@
   }
 
   /* Margin-bottom utilities */
-  .mb--xs { margin-bottom: var(--space-xs); }
-  .mb--sm { margin-bottom: var(--space-sm); }
-  .mb--sm-plus { margin-bottom: var(--space-sm-plus); }
-  .mb--md { margin-bottom: var(--space-md); }
+  .mb--xs {
+    margin-bottom: var(--space-xs);
+  }
+  .mb--sm {
+    margin-bottom: var(--space-sm);
+  }
+  .mb--sm-plus {
+    margin-bottom: var(--space-sm-plus);
+  }
+  .mb--md {
+    margin-bottom: var(--space-md);
+  }
 
   .section__title {
     font-family: var(--font-body);
@@ -582,6 +583,7 @@
   /* Right-side content */
   .hero__title {
     font-size: clamp(0.8125rem, 2vw, 0.9375rem);
+    letter-spacing: var(--tracking-wide);
     color: var(--text-secondary);
     margin-bottom: var(--space-sm-plus);
   }
@@ -718,7 +720,6 @@
     color: var(--text-primary);
     line-height: var(--leading-tight);
   }
-
 
   .accordion__teaser {
     grid-area: teaser;

--- a/index.css
+++ b/index.css
@@ -190,6 +190,7 @@
   .text--body {
     font-size: var(--font-size-base);
     color: var(--text-secondary);
+    line-height: var(--leading-relaxed);
   }
 
   /* ----- Column label (accordion body col heading pattern) ----- */
@@ -787,11 +788,6 @@
     .accordion__grid {
       grid-template-columns: repeat(3, 1fr);
     }
-  }
-
-  .accordion__col p {
-    color: var(--text-secondary);
-    line-height: var(--leading-relaxed);
   }
 
   /* ----- Badge Group ----- */

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
           </div>
 
           <div>
-            <div class="hero__title text--tag">
+            <div class="hero__title text--overline">
               <span>Frontend Architecture</span>
               <span class="hero__title-sep" aria-hidden="true"> · </span>
               <span>Design Systems</span>
@@ -261,7 +261,9 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--col-label mb--xs">My Technical Contribution</h4>
+                    <h4 class="text--col-label mb--xs">
+                      My Technical Contribution
+                    </h4>
                     <p>
                       Personally implemented core feature surfaces in React,
                       TypeScript, and GraphQL, including the data model
@@ -356,7 +358,9 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--col-label mb--xs">My Technical Contribution</h4>
+                    <h4 class="text--col-label mb--xs">
+                      My Technical Contribution
+                    </h4>
                     <p>
                       Owned the frontend architecture for Pocket's core UI
                       component library in React, TypeScript, and Storybook.

--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
                 <div class="accordion__grid">
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Context</h4>
-                    <p>
+                    <p class="text--body">
                       Pocket's core save-and-read loop was strong, but user
                       organization features had stagnated. Lists represented a
                       meaningful step toward helping readers manage large
@@ -237,7 +237,7 @@
                   </div>
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Who I Worked With</h4>
-                    <p>
+                    <p class="text--body">
                       Frontend engineers, backend engineers, a product manager,
                       UX designer, QA engineers, and the data team. Stakeholder
                       alignment across multiple time zones.
@@ -264,7 +264,7 @@
                     <h4 class="text--col-label mb--xs">
                       My Technical Contribution
                     </h4>
-                    <p>
+                    <p class="text--body">
                       Personally implemented core feature surfaces in React,
                       TypeScript, and GraphQL, including the data model
                       integration and UI components that shipped to users. Drove
@@ -315,7 +315,7 @@
                 <div class="accordion__grid">
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Context</h4>
-                    <p>
+                    <p class="text--body">
                       Pocket's card components - the core UI unit across the
                       product - had accumulated significant inconsistency and
                       technical debt. Each team was solving presentation
@@ -333,7 +333,7 @@
                   </div>
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Who I Worked With</h4>
-                    <p>
+                    <p class="text--body">
                       Frontend engineers across multiple teams, the design
                       system team, and UX designers. Required alignment with
                       product managers on prioritization of "invisible"
@@ -361,7 +361,7 @@
                     <h4 class="text--col-label mb--xs">
                       My Technical Contribution
                     </h4>
-                    <p>
+                    <p class="text--body">
                       Owned the frontend architecture for Pocket's core UI
                       component library in React, TypeScript, and Storybook.
                       Translated design tokens and component specs directly into
@@ -415,7 +415,7 @@
                 <div class="accordion__grid">
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Context</h4>
-                    <p>
+                    <p class="text--body">
                       Product teams wanted to test more, but the experimentation
                       infrastructure was inconsistent and the process for
                       running rigorous A/B tests wasn't well established.
@@ -438,7 +438,7 @@
                   </div>
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Who I Worked With</h4>
-                    <p>
+                    <p class="text--body">
                       Data engineers, product managers, frontend engineers, and
                       QA. Close collaboration with analytics to ensure
                       instrumentation was accurate and consistent.
@@ -506,7 +506,7 @@
                 <div class="accordion__grid">
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Context</h4>
-                    <p>
+                    <p class="text--body">
                       Mozilla launched a Mastodon-based social instance during
                       the broader Fediverse growth period. As a new product with
                       a small team and high public visibility, it required
@@ -533,7 +533,7 @@
                   </div>
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Who I Worked With</h4>
-                    <p>
+                    <p class="text--body">
                       Small, cross-functional team including product,
                       engineering, and trust & safety. Close alignment with
                       Mozilla's privacy and data governance teams.
@@ -599,7 +599,7 @@
                 <div class="accordion__grid">
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Context</h4>
-                    <p>
+                    <p class="text--body">
                       A client needed to expand their Webflow-based site to
                       support multiple language markets, without rebuilding from
                       scratch or introducing a content management burden that
@@ -623,7 +623,7 @@
                   </div>
                   <div class="accordion__col">
                     <h4 class="text--col-label mb--xs">Who I Worked With</h4>
-                    <p>
+                    <p class="text--body">
                       Client stakeholders, content editors, and a small
                       development team. Required close collaboration with
                       non-technical team members to ensure the solution fit

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
       >
         <div class="container">
           <header class="section__header">
-            <p class="section__eyebrow">How I Work</p>
+            <p class="section__eyebrow mb--sm">How I Work</p>
             <h2 class="section__title" id="philosophy-heading">
               Engineering Principles
             </h2>
@@ -178,7 +178,7 @@
       >
         <div class="container">
           <header class="section__header">
-            <p class="section__eyebrow">Case Studies</p>
+            <p class="section__eyebrow mb--sm">Case Studies</p>
             <h2 class="section__title" id="impact-heading">Selected Impact</h2>
             <p class="section__subtitle">
               Real work, real teams, real outcomes. Here's what leading
@@ -209,7 +209,7 @@
               <div class="accordion__body" id="cs-lists-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">Context</h4>
+                    <h4 class="text--col-label mb--xs">Context</h4>
                     <p>
                       Pocket's core save-and-read loop was strong, but user
                       organization features had stagnated. Lists represented a
@@ -220,7 +220,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Goals</h4>
+                    <h4 class="text--col-label mb--xs">Goals</h4>
                     <ul class="arrow-list">
                       <li>
                         Ship a production-quality Lists feature on schedule
@@ -236,7 +236,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Who I Worked With</h4>
+                    <h4 class="text--col-label mb--xs">Who I Worked With</h4>
                     <p>
                       Frontend engineers, backend engineers, a product manager,
                       UX designer, QA engineers, and the data team. Stakeholder
@@ -244,7 +244,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">What I Led</h4>
+                    <h4 class="text--col-label mb--xs">What I Led</h4>
                     <ul class="arrow-list">
                       <li>Owned planning, sequencing, and delivery tracking</li>
                       <li>
@@ -261,7 +261,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">My Technical Contribution</h4>
+                    <h4 class="text--col-label mb--xs">My Technical Contribution</h4>
                     <p>
                       Personally implemented core feature surfaces in React,
                       TypeScript, and GraphQL, including the data model
@@ -271,7 +271,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Results</h4>
+                    <h4 class="text--col-label mb--xs">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         17.6K lists created and 4.8% active engagement within
@@ -312,7 +312,7 @@
               <div class="accordion__body" id="cs-design-system-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">Context</h4>
+                    <h4 class="text--col-label mb--xs">Context</h4>
                     <p>
                       Pocket's card components - the core UI unit across the
                       product - had accumulated significant inconsistency and
@@ -322,7 +322,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Goals</h4>
+                    <h4 class="text--col-label mb--xs">Goals</h4>
                     <ul class="arrow-list">
                       <li>Establish a consistent, composable card anatomy</li>
                       <li>Reduce time-to-ship for UI changes across teams</li>
@@ -330,7 +330,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Who I Worked With</h4>
+                    <h4 class="text--col-label mb--xs">Who I Worked With</h4>
                     <p>
                       Frontend engineers across multiple teams, the design
                       system team, and UX designers. Required alignment with
@@ -339,7 +339,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">What I Led</h4>
+                    <h4 class="text--col-label mb--xs">What I Led</h4>
                     <ul class="arrow-list">
                       <li>
                         Built the case for prioritizing design system work
@@ -356,7 +356,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">My Technical Contribution</h4>
+                    <h4 class="text--col-label mb--xs">My Technical Contribution</h4>
                     <p>
                       Owned the frontend architecture for Pocket's core UI
                       component library in React, TypeScript, and Storybook.
@@ -367,7 +367,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Results</h4>
+                    <h4 class="text--col-label mb--xs">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         Significantly reduced UI inconsistency across the
@@ -410,7 +410,7 @@
               <div class="accordion__body" id="cs-experiments-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">Context</h4>
+                    <h4 class="text--col-label mb--xs">Context</h4>
                     <p>
                       Product teams wanted to test more, but the experimentation
                       infrastructure was inconsistent and the process for
@@ -420,7 +420,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Goals</h4>
+                    <h4 class="text--col-label mb--xs">Goals</h4>
                     <ul class="arrow-list">
                       <li>
                         Establish a reliable, repeatable experimentation process
@@ -433,7 +433,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Who I Worked With</h4>
+                    <h4 class="text--col-label mb--xs">Who I Worked With</h4>
                     <p>
                       Data engineers, product managers, frontend engineers, and
                       QA. Close collaboration with analytics to ensure
@@ -441,7 +441,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">What I Led</h4>
+                    <h4 class="text--col-label mb--xs">What I Led</h4>
                     <ul class="arrow-list">
                       <li>Defined experiment design and review standards</li>
                       <li>
@@ -457,7 +457,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Results</h4>
+                    <h4 class="text--col-label mb--xs">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         Teams moved from ad hoc testing to structured
@@ -501,7 +501,7 @@
               <div class="accordion__body" id="cs-social-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">Context</h4>
+                    <h4 class="text--col-label mb--xs">Context</h4>
                     <p>
                       Mozilla launched a Mastodon-based social instance during
                       the broader Fediverse growth period. As a new product with
@@ -511,7 +511,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Goals</h4>
+                    <h4 class="text--col-label mb--xs">Goals</h4>
                     <ul class="arrow-list">
                       <li>
                         Build a controlled, trust-based invite and onboarding
@@ -528,7 +528,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Who I Worked With</h4>
+                    <h4 class="text--col-label mb--xs">Who I Worked With</h4>
                     <p>
                       Small, cross-functional team including product,
                       engineering, and trust & safety. Close alignment with
@@ -536,7 +536,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">What I Led</h4>
+                    <h4 class="text--col-label mb--xs">What I Led</h4>
                     <ul class="arrow-list">
                       <li>Designed and owned the invite flow architecture</li>
                       <li>Built out analytics instrumentation from scratch</li>
@@ -550,7 +550,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Results</h4>
+                    <h4 class="text--col-label mb--xs">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         Invite system launched with controlled onboarding that
@@ -594,7 +594,7 @@
               <div class="accordion__body" id="cs-consulting-body" hidden>
                 <div class="accordion__grid">
                   <div class="accordion__col">
-                    <h4 class="text--overline">Context</h4>
+                    <h4 class="text--col-label mb--xs">Context</h4>
                     <p>
                       A client needed to expand their Webflow-based site to
                       support multiple language markets, without rebuilding from
@@ -604,7 +604,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Goals</h4>
+                    <h4 class="text--col-label mb--xs">Goals</h4>
                     <ul class="arrow-list">
                       <li>
                         Enable multilingual content delivery within platform
@@ -618,7 +618,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Who I Worked With</h4>
+                    <h4 class="text--col-label mb--xs">Who I Worked With</h4>
                     <p>
                       Client stakeholders, content editors, and a small
                       development team. Required close collaboration with
@@ -627,7 +627,7 @@
                     </p>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">What I Led</h4>
+                    <h4 class="text--col-label mb--xs">What I Led</h4>
                     <ul class="arrow-list">
                       <li>
                         Designed the content architecture and routing strategy
@@ -644,7 +644,7 @@
                     </ul>
                   </div>
                   <div class="accordion__col">
-                    <h4 class="text--overline">Results</h4>
+                    <h4 class="text--col-label mb--xs">Results</h4>
                     <ul class="arrow-list">
                       <li>
                         Multilingual content delivery live across target markets
@@ -671,13 +671,13 @@
       >
         <div class="container">
           <header class="section__header">
-            <p class="section__eyebrow">The Stack</p>
+            <p class="section__eyebrow mb--sm">The Stack</p>
             <h2 class="section__title" id="tech-heading">Technical Scope</h2>
           </header>
-          <div class="tech__groups grid--3col gap--lg">
-            <div class="tech__group">
-              <h3 class="text--overline">Languages & Frameworks</h3>
-              <div class="tech__chips">
+          <div class="grid--3col gap--lg">
+            <div class="badge-group">
+              <h3 class="text--overline mb--sm">Languages & Frameworks</h3>
+              <div class="badge-group__chips">
                 <span class="badge">React</span>
                 <span class="badge">TypeScript</span>
                 <span class="badge">JavaScript</span>
@@ -689,9 +689,9 @@
                 <span class="badge">Webflow CMS</span>
               </div>
             </div>
-            <div class="tech__group">
-              <h3 class="text--overline">Tooling & Systems</h3>
-              <div class="tech__chips">
+            <div class="badge-group">
+              <h3 class="text--overline mb--sm">Tooling & Systems</h3>
+              <div class="badge-group__chips">
                 <span class="badge">Storybook</span>
                 <span class="badge">Git / GitHub</span>
                 <span class="badge">CI/CD</span>
@@ -700,9 +700,9 @@
                 <span class="badge">Snowplow</span>
               </div>
             </div>
-            <div class="tech__group">
-              <h3 class="text--overline">Practices</h3>
-              <div class="tech__chips">
+            <div class="badge-group">
+              <h3 class="text--overline mb--sm">Practices</h3>
+              <div class="badge-group__chips">
                 <span class="badge">Design Systems</span>
                 <span class="badge">Frontend Architecture</span>
                 <span class="badge">A/B Experimentation</span>
@@ -723,7 +723,7 @@
         <div class="container">
           <div class="lets-talk__inner">
             <div class="lets-talk__content">
-              <p class="section__eyebrow">Get In Touch</p>
+              <p class="section__eyebrow mb--sm">Get In Touch</p>
               <h2 class="section__title" id="lets-talk-heading">
                 Interested in all this?<br />Let's talk.
               </h2>

--- a/styleguide.html
+++ b/styleguide.html
@@ -620,16 +620,8 @@
       <div class="sg-demo">
         <span class="text--overline" style="font-family:'Exo',sans-serif">Overline Label</span>
       </div>
-      <pre class="sg-code">&lt;p class="section__eyebrow"&gt;Overline Label&lt;/p&gt;</pre>
+      <pre class="sg-code">&lt;p class="text--overline"&gt;Overline Label&lt;/p&gt;</pre>
       <p class="sg-note"><strong>font-weight: --weight-semibold</strong>, uppercase. Used for section eyebrows and accordion org labels.</p>
-    </div>
-
-    <div class="sg-component-demo">
-      <div class="sg-demo">
-        <span class="text--tag" style="font-family:'Exo',sans-serif">Tag Label</span>
-      </div>
-      <pre class="sg-code">&lt;span class="text--tag"&gt;Tag Label&lt;/span&gt;</pre>
-      <p class="sg-note"><strong>font-weight: --weight-medium</strong>, uppercase, <strong>--tracking-wide</strong>. Used on hero subtitle and case study category tags.</p>
     </div>
 
     <div class="sg-component-demo">
@@ -660,7 +652,7 @@
         <span class="badge" style="font-family:'Exo',sans-serif">Category Tag</span>
       </div>
       <pre class="sg-code">&lt;span class="badge"&gt;Category Tag&lt;/span&gt;</pre>
-      <p class="sg-note">Pill-shaped label. <strong>--font-size-sm</strong>, <strong>--text-secondary</strong>, <strong>--surface-hover-md</strong> background, <strong>--border-subtle</strong> border, <strong>--radius-pill</strong>. Pair with <code>.text--tag</code> for uppercase tracking. Used on accordion items to label content type.</p>
+      <p class="sg-note">Pill-shaped label. <strong>--font-size-sm</strong>, <strong>--text-secondary</strong>, <strong>--surface-hover-md</strong> background, <strong>--border-subtle</strong> border, <strong>--radius-pill</strong>. Used on accordion items to label content type.</p>
     </div>
 
     <div class="sg-component-demo">
@@ -851,11 +843,11 @@
           <div class="accordion__body" id="sg-cs-demo-body">
             <div class="accordion__grid">
               <div class="accordion__col">
-                <h4 class="text--overline">Context</h4>
+                <h4 class="text--col-label mb--xs">Context</h4>
                 <p>Background prose about the problem space and situation.</p>
               </div>
               <div class="accordion__col">
-                <h4 class="text--overline">Goals</h4>
+                <h4 class="text--col-label mb--xs">Goals</h4>
                 <ul class="arrow-list">
                   <li>Deliver the feature on schedule</li>
                   <li>Improve team collaboration rituals</li>
@@ -863,7 +855,7 @@
                 </ul>
               </div>
               <div class="accordion__col">
-                <h4 class="text--overline">What I Learned</h4>
+                <h4 class="text--col-label mb--xs">What I Learned</h4>
                 <p>Reflective prose about key takeaways from the engagement.</p>
               </div>
             </div>
@@ -885,11 +877,11 @@
     &lt;div class="accordion__body" id="cs-id-body" hidden&gt;
       &lt;div class="accordion__grid"&gt;
         &lt;div class="accordion__col"&gt;
-          &lt;h4 class="text--overline"&gt;Context&lt;/h4&gt;
+          &lt;h4 class="text--col-label mb--xs"&gt;Context&lt;/h4&gt;
           &lt;p&gt;Prose.&lt;/p&gt;
         &lt;/div&gt;
         &lt;div class="accordion__col"&gt;
-          &lt;h4 class="text--overline"&gt;Goals&lt;/h4&gt;
+          &lt;h4 class="text--col-label mb--xs"&gt;Goals&lt;/h4&gt;
           &lt;ul class="arrow-list"&gt;
             &lt;li&gt;Goal one&lt;/li&gt;
           &lt;/ul&gt;

--- a/styleguide.html
+++ b/styleguide.html
@@ -690,34 +690,34 @@
     <div class="sg-demo sg-demo--row">
       <a href="#" class="btn btn--primary">Primary</a>
       <a href="#" class="btn btn--ghost">Ghost</a>
-      <button class="btn btn--sm btn--rainbow" aria-pressed="false"><span class="btn__icon" aria-hidden="true">🌈</span> Rainbow Time</button>
+      <button class="btn btn--sm btn--rainbow" aria-pressed="false"><span class="btn__icon" aria-hidden="true">🌈</span></button>
     </div>
     <pre class="sg-code">&lt;a href="#" class="btn btn--primary"&gt;Primary&lt;/a&gt;
 &lt;a href="#" class="btn btn--ghost"&gt;Ghost&lt;/a&gt;
 &lt;button class="btn btn--sm btn--rainbow" aria-pressed="false"&gt;
-  &lt;span class="btn__icon" aria-hidden="true"&gt;🌈&lt;/span&gt; Rainbow Time
+  &lt;span class="btn__icon" aria-hidden="true"&gt;🌈&lt;/span&gt;
 &lt;/button&gt;</pre>
 
     <h2 class="sg-subheading" id="buttons-sm">Small — <code>.btn--sm</code></h2>
     <div class="sg-demo sg-demo--row">
       <a href="#" class="btn btn--sm btn--primary">Primary</a>
       <a href="#" class="btn btn--sm btn--ghost">Ghost</a>
-      <button class="btn btn--sm btn--rainbow" aria-pressed="false"><span class="btn__icon" aria-hidden="true">🌈</span> Rainbow Time</button>
+      <button class="btn btn--sm btn--rainbow" aria-pressed="false"><span class="btn__icon" aria-hidden="true">🌈</span></button>
     </div>
     <pre class="sg-code">&lt;a href="#" class="btn btn--sm btn--primary"&gt;Primary&lt;/a&gt;
 &lt;a href="#" class="btn btn--sm btn--ghost"&gt;Ghost&lt;/a&gt;
 &lt;button class="btn btn--sm btn--rainbow" aria-pressed="false"&gt;
-  &lt;span class="btn__icon" aria-hidden="true"&gt;🌈</span> Rainbow Time
+  &lt;span class="btn__icon" aria-hidden="true"&gt;🌈&lt;/span&gt;
 &lt;/button&gt;</pre>
 
     <h2 class="sg-subheading" id="buttons-rainbow">Rainbow — pressed state</h2>
     <div class="sg-demo sg-demo--row">
-      <button class="btn btn--sm btn--rainbow" aria-pressed="true"><span class="btn__icon" aria-hidden="true">🌈</span> Rainbow Time</button>
+      <button class="btn btn--sm btn--rainbow" aria-pressed="true"><span class="btn__icon" aria-hidden="true">🌈</span></button>
     </div>
     <pre class="sg-code">&lt;button class="btn btn--sm btn--rainbow" aria-pressed="true"&gt;
-  &lt;span class="btn__icon" aria-hidden="true"&gt;🌈&lt;/span&gt; Rainbow Time
+  &lt;span class="btn__icon" aria-hidden="true"&gt;🌈&lt;/span&gt;
 &lt;/button&gt;</pre>
-    <p class="sg-note"><strong>Hover:</strong> btn--primary lifts (translateY -2px) + glow shadow, border brightens. btn--ghost border brightens, text becomes primary. btn--rainbow border brightens, subtle background appears, icon rotates 20° and scales. <strong>Note:</strong> btn--rainbow uses <code>aria-pressed</code> to reflect toggle state — JS sets this on interaction.</p>
+    <p class="sg-note"><strong>Hover:</strong> All buttons lift (translateY -2px) via <code>.btn:hover</code>. btn--primary also gains a glow shadow and the gradient border brightens to full opacity. btn--ghost border brightens, text becomes primary. btn--rainbow border brightens, subtle background appears, icon rotates 20° and scales. <strong>Note:</strong> btn--rainbow uses <code>aria-pressed</code> to reflect toggle state — JS sets this on interaction.</p>
   </section>
 
   <!-- ============================================================
@@ -875,7 +875,6 @@
     &lt;button class="btn btn--sm btn--rainbow" id="rainbowToggle"
             aria-pressed="false" aria-label="Toggle Rainbow Time mode"&gt;
       &lt;span class="btn__icon" aria-hidden="true"&gt;🌈&lt;/span&gt;
-      &lt;span&gt;Rainbow Time&lt;/span&gt;
     &lt;/button&gt;
   &lt;/div&gt;
 &lt;/nav&gt;</pre>
@@ -899,7 +898,7 @@
           <div class="footer__bottom">
             <span class="footer__copy">Just HTML, CSS, and strong opinions.</span>
             <button class="btn btn--sm btn--rainbow" aria-pressed="false" aria-label="Toggle Rainbow Time mode">
-              <span class="btn__icon" aria-hidden="true">🌈</span> Rainbow Time
+              <span class="btn__icon" aria-hidden="true">🌈</span>
             </button>
           </div>
         </div>
@@ -917,7 +916,7 @@
     &lt;div class="footer__bottom"&gt;
       &lt;span class="footer__copy"&gt;Copy text.&lt;/span&gt;
       &lt;button class="btn btn--sm btn--rainbow" aria-pressed="false"&gt;
-        &lt;span class="btn__icon" aria-hidden="true"&gt;🌈&lt;/span&gt; Rainbow Time
+        &lt;span class="btn__icon" aria-hidden="true"&gt;🌈&lt;/span&gt;
       &lt;/button&gt;
     &lt;/div&gt;
   &lt;/div&gt;
@@ -966,11 +965,11 @@
     <h2 class="sg-subheading" id="motion-transitions">Transition Patterns</h2>
     <div class="sg-motion-row">
       <span class="sg-type-label">btn--primary hover</span>
-      <span style="color:var(--text-secondary);font-size:var(--font-size-base);">translateY(-2px) + box-shadow glow. Gradient border <code>::before</code> opacity 0.7 → 1.</span>
+      <span style="color:var(--text-secondary);font-size:var(--font-size-base);">Gradient border <code>::before</code> opacity 0.7 → 1, plus box-shadow glow. Lift (translateY -2px) is inherited from <code>.btn:hover</code>.</span>
     </div>
     <div class="sg-motion-row">
       <span class="sg-type-label">btn--ghost hover</span>
-      <span style="color:var(--text-secondary);font-size:var(--font-size-base);">translateY(-2px), border brightens to <code>--border-hover</code>, text becomes <code>--text-primary</code>.</span>
+      <span style="color:var(--text-secondary);font-size:var(--font-size-base);">Border brightens to <code>--border-hover</code>, text becomes <code>--text-primary</code>. Lift inherited from <code>.btn:hover</code>.</span>
     </div>
     <div class="sg-motion-row">
       <span class="sg-type-label">btn--rainbow hover / pressed</span>
@@ -1004,54 +1003,59 @@
     <h2 class="sg-subheading" id="rainbow-tokens">Overridden Tokens</h2>
     <div class="sg-token-grid">
       <div class="sg-token">
-        <div class="sg-swatch" style="background:#ff0080;"></div>
+        <div class="sg-swatch" style="background:#ff3cac;"></div>
         <span class="sg-token__name">--grad-start</span>
-        <span class="sg-token__value">#ff0080 (was #00dbde)</span>
+        <span class="sg-token__value">#ff3cac (was #00dbde)</span>
       </div>
       <div class="sg-token">
-        <div class="sg-swatch" style="background:#7928ca;"></div>
+        <div class="sg-swatch" style="background:#6366f1;"></div>
         <span class="sg-token__name">--grad-end</span>
-        <span class="sg-token__value">#7928ca (was #fc00ff)</span>
+        <span class="sg-token__value">#6366f1 (was #fc00ff)</span>
       </div>
       <div class="sg-token">
-        <div class="sg-swatch" style="background:#0affef;"></div>
+        <div class="sg-swatch" style="background:#22d3ee;"></div>
         <span class="sg-token__name">--accent-cyan</span>
-        <span class="sg-token__value">#0affef (was #00dbde)</span>
+        <span class="sg-token__value">#22d3ee (was #00dbde)</span>
       </div>
       <div class="sg-token">
-        <div class="sg-swatch" style="background:#ff6ec7;"></div>
+        <div class="sg-swatch" style="background:#ff3cac;"></div>
         <span class="sg-token__name">--accent-pink</span>
-        <span class="sg-token__value">#ff6ec7 (was #fc00ff)</span>
+        <span class="sg-token__value">#ff3cac (was #fc00ff)</span>
       </div>
       <div class="sg-token">
-        <div class="sg-swatch" style="background:rgba(121,40,202,0.25);"></div>
-        <span class="sg-token__name">--accent-glow</span>
-        <span class="sg-token__value">rgba(121,40,202,0.25) — purple glow</span>
+        <div class="sg-swatch" style="background:#ff7a18;"></div>
+        <span class="sg-token__name">--rainbow-orange</span>
+        <span class="sg-token__value">#ff7a18 — rainbow spectrum stop</span>
       </div>
       <div class="sg-token">
-        <div class="sg-swatch" style="background:rgba(10,255,239,0.07);"></div>
-        <span class="sg-token__name">--accent-cyan-subtle</span>
-        <span class="sg-token__value">rgba(10,255,239,0.07) — hero bg glow</span>
+        <div class="sg-swatch" style="background:#ff00cc;"></div>
+        <span class="sg-token__name">--rainbow-magenta</span>
+        <span class="sg-token__value">#ff00cc — rainbow spectrum stop</span>
       </div>
       <div class="sg-token">
-        <div class="sg-swatch" style="background:rgba(255,110,199,0.07);"></div>
-        <span class="sg-token__name">--accent-pink-subtle</span>
-        <span class="sg-token__value">rgba(255,110,199,0.07) — hero bg glow</span>
+        <div class="sg-swatch" style="background:#9333ea;"></div>
+        <span class="sg-token__name">--rainbow-purple</span>
+        <span class="sg-token__value">#9333ea — rainbow spectrum stop</span>
       </div>
       <div class="sg-token">
-        <div class="sg-swatch" style="background:rgba(5,5,26,0.7);"></div>
-        <span class="sg-token__name">--bg-nav</span>
-        <span class="sg-token__value">rgba(5,5,26,0.7) — nav desktop backdrop</span>
+        <div class="sg-swatch" style="background:#3b82f6;"></div>
+        <span class="sg-token__name">--rainbow-blue</span>
+        <span class="sg-token__value">#3b82f6 — rainbow spectrum stop</span>
       </div>
       <div class="sg-token">
-        <div class="sg-swatch" style="background:rgba(5,5,26,0.96);"></div>
-        <span class="sg-token__name">--bg-nav-solid</span>
-        <span class="sg-token__value">rgba(5,5,26,0.96) — nav mobile</span>
-      </div>
-      <div class="sg-token">
-        <div class="sg-swatch" style="background:linear-gradient(to right,#ff0080,#ff8c00,#ffe600,#00ff88,#00c6ff,#7928ca);"></div>
+        <div class="sg-swatch" style="background:linear-gradient(to right,#ff7a18,#ff3cac,#ff00cc,#9333ea,#6366f1,#3b82f6,#22d3ee);"></div>
         <span class="sg-token__name">--rainbow-gradient</span>
-        <span class="sg-token__value">hot pink → orange → yellow → green → sky → purple</span>
+        <span class="sg-token__value">orange → pink → magenta → purple → indigo → blue → cyan (horizontal)</span>
+      </div>
+      <div class="sg-token">
+        <div class="sg-swatch" style="background:linear-gradient(135deg,#ff7a18,#ff3cac,#ff00cc,#9333ea,#6366f1,#3b82f6,#22d3ee);"></div>
+        <span class="sg-token__name">--rainbow-gradient-diagonal</span>
+        <span class="sg-token__value">same spectrum at 135° — used for odd card borders and btn--primary border</span>
+      </div>
+      <div class="sg-token">
+        <div class="sg-swatch" style="background:linear-gradient(-135deg,#22d3ee,#3b82f6,#6366f1,#9333ea,#ff00cc,#ff3cac,#ff7a18);"></div>
+        <span class="sg-token__name">--rainbow-gradient-diagonal-reverse</span>
+        <span class="sg-token__value">reversed spectrum at -135° — used for even card borders</span>
       </div>
     </div>
 
@@ -1071,11 +1075,11 @@
       </div>
       <div class="sg-motion-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">.card</span>
-        <span style="color:var(--text-secondary);">Border replaced with full-spectrum gradient via background-clip: border-box trick</span>
+        <span style="color:var(--text-secondary);">Border replaced with full-spectrum gradient via background-clip: border-box. Odd cards use --rainbow-gradient-diagonal; even cards use --rainbow-gradient-diagonal-reverse</span>
       </div>
       <div class="sg-motion-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">.btn--primary::before</span>
-        <span style="color:var(--text-secondary);">Gradient border swaps from --gradient to --rainbow-gradient</span>
+        <span style="color:var(--text-secondary);">Gradient border swaps from --gradient to --rainbow-gradient-diagonal</span>
       </div>
     </div>
     <p class="sg-note" style="margin-top:var(--space-sm);">The two rainbow toggle buttons (<code>#rainbowToggle</code> and <code>#rainbowToggleFooter</code>) both have their <code>aria-pressed</code> attribute managed by JS in <code>index.js → initRainbow()</code>.</p>

--- a/styleguide.html
+++ b/styleguide.html
@@ -288,11 +288,15 @@
   <a href="#layout-container" class="sg-nav__sub">Container</a>
   <a href="#layout-section" class="sg-nav__sub">Section</a>
   <a href="#layout-section-header" class="sg-nav__sub">Section Header</a>
+  <a href="#layout-bg" class="sg-nav__sub">Background Utils</a>
+  <a href="#layout-grid" class="sg-nav__sub">Grid — 3col</a>
+  <a href="#layout-gap" class="sg-nav__sub">Gap Utils</a>
 
   <a href="#components" class="sg-nav__section">Components</a>
   <a href="#components-card" class="sg-nav__sub">Card</a>
   <a href="#components-accordion" class="sg-nav__sub">Accordion</a>
   <a href="#components-nav" class="sg-nav__sub">Nav</a>
+  <a href="#components-tech" class="sg-nav__sub">Tech Experience</a>
   <a href="#components-footer" class="sg-nav__sub">Footer</a>
 
   <a href="#motion" class="sg-nav__section">Motion</a>
@@ -765,6 +769,40 @@
   &lt;p class="section__subtitle"&gt;Subtitle text here.&lt;/p&gt;
 &lt;/header&gt;</pre>
     <p class="sg-note">Spacing: eyebrow <strong>margin-bottom: 0.75rem</strong>, title <strong>margin-bottom: 1rem</strong>, subtitle <strong>margin-bottom: var(--space-sm-plus)</strong>. Header itself: <strong>margin-bottom: var(--space-lg)</strong>.</p>
+
+    <h2 class="sg-subheading" id="layout-bg">Background Utilities</h2>
+    <p class="sg-desc">Semantic background color classes. Use these instead of inlining token values so section backgrounds stay in sync with the palette.</p>
+    <div class="sg-token-grid">
+      <div class="sg-token">
+        <div class="sg-swatch" style="background:#080818;"></div>
+        <span class="sg-token__name">.bg--base</span>
+        <span class="sg-token__value">var(--bg-base) — default page background</span>
+      </div>
+      <div class="sg-token">
+        <div class="sg-swatch" style="background:#0e0e24;"></div>
+        <span class="sg-token__name">.bg--section</span>
+        <span class="sg-token__value">var(--bg-section) — alternating section background</span>
+      </div>
+    </div>
+    <pre class="sg-code">&lt;section class="section bg--section"&gt;…&lt;/section&gt;</pre>
+
+    <h2 class="sg-subheading" id="layout-grid">Grid — 3 Column</h2>
+    <p class="sg-desc">Responsive 3-column grid. 1-col on mobile, 2-col at 640px, 3-col at 960px. Used for cards, tech chips, and any uniform-item layouts.</p>
+    <pre class="sg-code">&lt;div class="grid--3col gap--sm-plus"&gt;
+  &lt;!-- items --&gt;
+&lt;/div&gt;</pre>
+    <p class="sg-note">Pair with a <strong>gap--*</strong> utility to control spacing. <code>gap--sm-plus</code> is the standard card grid gap.</p>
+
+    <h2 class="sg-subheading" id="layout-gap">Gap Utilities</h2>
+    <p class="sg-desc">Composable gap classes that map directly to the spacing scale. Apply to any flex or grid container.</p>
+    <div class="sg-token-grid" style="grid-template-columns:1fr;">
+      <div class="sg-token"><span class="sg-token__name">.gap--xs</span><span class="sg-token__value">var(--space-xs) — 8px</span></div>
+      <div class="sg-token"><span class="sg-token__name">.gap--sm</span><span class="sg-token__value">var(--space-sm) — 16px</span></div>
+      <div class="sg-token"><span class="sg-token__name">.gap--sm-plus</span><span class="sg-token__value">var(--space-sm-plus) — 24px — standard card/chip gap</span></div>
+      <div class="sg-token"><span class="sg-token__name">.gap--md</span><span class="sg-token__value">var(--space-md) — 32px</span></div>
+      <div class="sg-token"><span class="sg-token__name">.gap--lg</span><span class="sg-token__value">var(--space-lg) — 64px</span></div>
+      <div class="sg-token"><span class="sg-token__name">.gap--xl</span><span class="sg-token__value">var(--space-xl) — 128px</span></div>
+    </div>
   </section>
 
   <!-- ============================================================
@@ -775,7 +813,7 @@
 
     <!-- CARD -->
     <h2 class="sg-subheading" id="components-card">Card</h2>
-    <p class="sg-desc">Used in the Philosophy section. A 4-column grid on desktop, 2-col on tablet, 1-col on mobile. Cards lift on hover with a pink glow.</p>
+    <p class="sg-desc">Used in the Philosophy section inside a <code>.grid--3col</code> wrapper. 3-col on desktop, 2-col on tablet, 1-col on mobile. Cards lift on hover with a pink glow.</p>
     <div class="sg-demo">
       <div class="sg-card-wrap">
         <article class="card">
@@ -879,6 +917,29 @@
   &lt;/div&gt;
 &lt;/nav&gt;</pre>
     <p class="sg-note"><code>.nav.scrolled</code> adds a border and shadow — applied by JS on scroll. <code>.nav.name-visible</code> fades the wordmark in — applied by JS via IntersectionObserver on the hero name.</p>
+
+    <!-- TECHNICAL EXPERIENCE -->
+    <h2 class="sg-subheading" id="components-tech">Technical Experience</h2>
+    <p class="sg-desc">Displays grouped technology stacks as labeled chip clusters. Each group has an overline heading and a flex-wrapped chip row using <code>.badge</code> elements.</p>
+    <div class="sg-demo">
+      <div class="tech__group">
+        <p class="text--overline" style="font-family:'Exo',sans-serif;font-size:var(--font-size-xs);letter-spacing:var(--tracking-wider);margin-bottom:var(--space-sm);">Frontend</p>
+        <div class="tech__chips">
+          <span class="badge">React</span>
+          <span class="badge">TypeScript</span>
+          <span class="badge">CSS</span>
+          <span class="badge">Next.js</span>
+        </div>
+      </div>
+    </div>
+    <pre class="sg-code">&lt;div class="tech__group"&gt;
+  &lt;p class="text--overline"&gt;Group Label&lt;/p&gt;
+  &lt;div class="tech__chips"&gt;
+    &lt;span class="badge"&gt;Chip&lt;/span&gt;
+    &lt;span class="badge"&gt;Chip&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</pre>
+    <p class="sg-note"><code>.tech__chips</code> is <code>display: flex; flex-wrap: wrap; gap: var(--space-xs)</code>. Uses <code>.badge</code> for the individual chips. Groups are placed inside a <code>.grid--3col</code> wrapper in the page.</p>
 
     <!-- FOOTER -->
     <h2 class="sg-subheading" id="components-footer">Footer</h2>

--- a/styleguide.html
+++ b/styleguide.html
@@ -15,7 +15,7 @@
     /* Style guide chrome — uses project tokens, not inline values */
 
     /* Override body font to Inter for chrome; Exo still renders via
-       var(--font-display) on .sg-heading and all component demos */
+       var(--font-body) on .sg-heading and all component demos */
     body {
       font-family: "Inter", system-ui, sans-serif;
     }
@@ -54,7 +54,7 @@
     .sg-nav__section:first-child { margin-top: 0; }
 
     .sg-nav__sub {
-      font-size: var(--font-size-xs);
+      font-size: var(--font-size-sm);
       color: var(--text-secondary);
       transition: color var(--duration);
       white-space: nowrap;
@@ -77,7 +77,7 @@
     .sg-section:first-of-type { border-top: none; }
 
     .sg-heading {
-      font-family: var(--font-display);
+      font-family: var(--font-body);
       font-size: var(--font-size-xl);
       letter-spacing: var(--tracking-tight);
       color: var(--text-primary);
@@ -120,14 +120,14 @@
     }
 
     .sg-token__name {
-      font-size: var(--font-size-xs);
+      font-size: var(--font-size-sm);
       letter-spacing: var(--tracking-wider);
       color: var(--accent-pink);
       font-family: monospace;
     }
 
     .sg-token__value {
-      font-size: var(--font-size-xs);
+      font-size: var(--font-size-sm);
       color: var(--text-secondary);
       font-family: monospace;
     }
@@ -172,7 +172,7 @@
 
     .sg-type-label {
       font-family: monospace;
-      font-size: var(--font-size-xs);
+      font-size: var(--font-size-sm);
       color: var(--accent-pink);
       min-width: 18ch;
       flex-shrink: 0;
@@ -180,7 +180,7 @@
 
     .sg-type-meta {
       font-family: monospace;
-      font-size: var(--font-size-xs);
+      font-size: var(--font-size-sm);
       color: var(--text-secondary);
       min-width: 8ch;
       flex-shrink: 0;
@@ -291,12 +291,13 @@
   <a href="#layout-bg" class="sg-nav__sub">Background Utils</a>
   <a href="#layout-grid" class="sg-nav__sub">Grid — 3col</a>
   <a href="#layout-gap" class="sg-nav__sub">Gap Utils</a>
+  <a href="#layout-mb" class="sg-nav__sub">Margin-Bottom Utils</a>
 
   <a href="#components" class="sg-nav__section">Components</a>
   <a href="#components-card" class="sg-nav__sub">Card</a>
   <a href="#components-accordion" class="sg-nav__sub">Accordion</a>
   <a href="#components-nav" class="sg-nav__sub">Nav</a>
-  <a href="#components-tech" class="sg-nav__sub">Tech Experience</a>
+  <a href="#components-badge-group" class="sg-nav__sub">Badge Group</a>
   <a href="#components-footer" class="sg-nav__sub">Footer</a>
 
   <a href="#motion" class="sg-nav__section">Motion</a>
@@ -513,14 +514,9 @@
     <h2 class="sg-subheading" id="type-families">Font Families</h2>
     <div class="sg-token-grid">
       <div class="sg-token">
-        <span style="font-family:'Exo',sans-serif;font-size:var(--font-size-xl);color:var(--text-primary);">Exo</span>
-        <span class="sg-token__name">--font-display</span>
-        <span class="sg-token__value">"Exo", sans-serif — headings, wordmark</span>
-      </div>
-      <div class="sg-token">
         <span style="font-family:'Exo','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:var(--font-size-xl);color:var(--text-primary);">Exo</span>
         <span class="sg-token__name">--font-body</span>
-        <span class="sg-token__value">"Exo" + system fallbacks — body text, UI</span>
+        <span class="sg-token__value">"Exo" + system fallbacks — single token for all type: headings, body, UI</span>
       </div>
     </div>
 
@@ -528,34 +524,19 @@
     <h2 class="sg-subheading" id="type-size">Font Size Scale</h2>
     <div class="sg-token" style="padding:0;overflow:hidden;">
       <div class="sg-type-row" style="padding:var(--space-sm);">
-        <span class="sg-type-label">--font-size-xs</span>
-        <span class="sg-type-meta">0.6875rem / 11px</span>
-        <span style="font-family:'Exo',sans-serif;font-size:0.6875rem;color:var(--text-secondary);">Tag labels, marker arrows</span>
-      </div>
-      <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--font-size-sm</span>
         <span class="sg-type-meta">0.75rem / 12px</span>
-        <span style="font-family:'Exo',sans-serif;font-size:0.75rem;color:var(--text-secondary);">Eyebrows, overlines, small labels, btn--sm</span>
-      </div>
-      <div class="sg-type-row" style="padding:var(--space-sm);">
-        <span class="sg-type-label">--font-size-ui</span>
-        <span class="sg-type-meta">0.875rem / 14px</span>
-        <span style="font-family:'Exo',sans-serif;font-size:0.875rem;color:var(--text-secondary);">UI chrome — toggles, footer copy, links &amp; tagline</span>
+        <span style="font-family:'Exo',sans-serif;font-size:0.75rem;color:var(--text-secondary);">Labels, badges, eyebrows, arrows, btn--sm</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--font-size-base</span>
         <span class="sg-type-meta">0.9375rem / 15px</span>
-        <span style="font-family:'Exo',sans-serif;font-size:0.9375rem;color:var(--text-secondary);">Primary body text</span>
-      </div>
-      <div class="sg-type-row" style="padding:var(--space-sm);">
-        <span class="sg-type-label">--font-size-md</span>
-        <span class="sg-type-meta">1.0625rem / 17px</span>
-        <span style="font-family:'Exo',sans-serif;font-size:1.0625rem;color:var(--text-secondary);">Lead text, section subtitle</span>
+        <span style="font-family:'Exo',sans-serif;font-size:0.9375rem;color:var(--text-secondary);">Body text, UI chrome (footer copy, links, tagline)</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--font-size-lg</span>
         <span class="sg-type-meta">1.125rem / 18px</span>
-        <span style="font-family:'Exo',sans-serif;font-size:1.125rem;color:var(--text-secondary);">Component headings</span>
+        <span style="font-family:'Exo',sans-serif;font-size:1.125rem;color:var(--text-secondary);">Component headings, section subtitle / lead text</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--font-size-xl</span>
@@ -575,17 +556,17 @@
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--weight-normal</span>
         <span class="sg-type-meta">400</span>
-        <span style="font-family:'Exo',sans-serif;font-weight:400;font-size:var(--font-size-md);">The quick brown fox</span>
+        <span style="font-family:'Exo',sans-serif;font-weight:400;font-size:var(--font-size-lg);">The quick brown fox</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--weight-medium</span>
         <span class="sg-type-meta">500</span>
-        <span style="font-family:'Exo',sans-serif;font-weight:500;font-size:var(--font-size-md);">The quick brown fox</span>
+        <span style="font-family:'Exo',sans-serif;font-weight:500;font-size:var(--font-size-lg);">The quick brown fox</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--weight-semibold</span>
         <span class="sg-type-meta">600</span>
-        <span style="font-family:'Exo',sans-serif;font-weight:600;font-size:var(--font-size-md);">The quick brown fox</span>
+        <span style="font-family:'Exo',sans-serif;font-weight:600;font-size:var(--font-size-lg);">The quick brown fox</span>
       </div>
     </div>
 
@@ -595,32 +576,32 @@
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--tracking-tighter</span>
         <span class="sg-type-meta">-0.02em</span>
-        <span style="font-family:'Exo',sans-serif;letter-spacing:-0.02em;font-size:var(--font-size-md);">Display name</span>
+        <span style="font-family:'Exo',sans-serif;letter-spacing:-0.02em;font-size:var(--font-size-lg);">Display name</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--tracking-tight</span>
         <span class="sg-type-meta">-0.01em</span>
-        <span style="font-family:'Exo',sans-serif;letter-spacing:-0.01em;font-size:var(--font-size-md);">Section titles, wordmark</span>
+        <span style="font-family:'Exo',sans-serif;letter-spacing:-0.01em;font-size:var(--font-size-lg);">Section titles, wordmark</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--tracking-normal</span>
         <span class="sg-type-meta">0.01em</span>
-        <span style="font-family:'Exo',sans-serif;letter-spacing:0.01em;font-size:var(--font-size-md);">Default slight open</span>
+        <span style="font-family:'Exo',sans-serif;letter-spacing:0.01em;font-size:var(--font-size-lg);">Default slight open</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--tracking-wide</span>
         <span class="sg-type-meta">0.06em</span>
-        <span style="font-family:'Exo',sans-serif;letter-spacing:0.06em;font-size:var(--font-size-md);">Hero title, uppercase tags</span>
+        <span style="font-family:'Exo',sans-serif;letter-spacing:0.06em;font-size:var(--font-size-lg);">Hero title, uppercase tags</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--tracking-wider</span>
         <span class="sg-type-meta">0.1em</span>
-        <span style="font-family:'Exo',sans-serif;letter-spacing:0.1em;font-size:var(--font-size-md);">Org labels, col titles</span>
+        <span style="font-family:'Exo',sans-serif;letter-spacing:0.1em;font-size:var(--font-size-lg);">Org labels, col titles</span>
       </div>
       <div class="sg-type-row" style="padding:var(--space-sm);">
         <span class="sg-type-label">--tracking-widest</span>
         <span class="sg-type-meta">0.12em</span>
-        <span style="font-family:'Exo',sans-serif;letter-spacing:0.12em;font-size:var(--font-size-md);">Section eyebrow</span>
+        <span style="font-family:'Exo',sans-serif;letter-spacing:0.12em;font-size:var(--font-size-lg);">Section eyebrow</span>
       </div>
     </div>
 
@@ -629,7 +610,7 @@
 
     <div class="sg-component-demo">
       <div class="sg-demo">
-        <span class="gradient-text" style="font-size:var(--font-size-xl);font-family:var(--font-display);">Gradient Text</span>
+        <span class="gradient-text" style="font-size:var(--font-size-xl);font-family:var(--font-body);">Gradient Text</span>
       </div>
       <pre class="sg-code">&lt;span class="gradient-text"&gt;Gradient Text&lt;/span&gt;</pre>
       <p class="sg-note">Applies the <strong>--gradient</strong> as a clipped background. Used on the hero name, nav wordmark, footer name, and the ✦ glyph. Transitions to <strong>--rainbow-gradient</strong> in rainbow mode.</p>
@@ -679,7 +660,15 @@
         <span class="badge" style="font-family:'Exo',sans-serif">Category Tag</span>
       </div>
       <pre class="sg-code">&lt;span class="badge"&gt;Category Tag&lt;/span&gt;</pre>
-      <p class="sg-note">Pill-shaped label. <strong>--font-size-xs</strong>, <strong>--text-secondary</strong>, <strong>--surface-hover-md</strong> background, <strong>--border-subtle</strong> border, <strong>--radius-pill</strong>. Pair with <code>.text--tag</code> for uppercase tracking. Used on accordion items to label content type.</p>
+      <p class="sg-note">Pill-shaped label. <strong>--font-size-sm</strong>, <strong>--text-secondary</strong>, <strong>--surface-hover-md</strong> background, <strong>--border-subtle</strong> border, <strong>--radius-pill</strong>. Pair with <code>.text--tag</code> for uppercase tracking. Used on accordion items to label content type.</p>
+    </div>
+
+    <div class="sg-component-demo">
+      <div class="sg-demo">
+        <h4 class="text--col-label" style="font-family:'Exo',sans-serif;">Column Label</h4>
+      </div>
+      <pre class="sg-code">&lt;h4 class="text--col-label mb--xs"&gt;Column Label&lt;/h4&gt;</pre>
+      <p class="sg-note"><strong>--font-size-sm</strong>, <strong>--weight-semibold</strong>, uppercase, <strong>--tracking-wider</strong>, <strong>--accent-pink</strong>. Used for accordion body column headings (Context, Goals, Results, etc.). Pair with <code>.mb--xs</code> for spacing below.</p>
     </div>
   </section>
 
@@ -803,6 +792,15 @@
       <div class="sg-token"><span class="sg-token__name">.gap--lg</span><span class="sg-token__value">var(--space-lg) — 64px</span></div>
       <div class="sg-token"><span class="sg-token__name">.gap--xl</span><span class="sg-token__value">var(--space-xl) — 128px</span></div>
     </div>
+
+    <h2 class="sg-subheading" id="layout-mb">Margin-Bottom Utilities</h2>
+    <p class="sg-desc">Composable margin-bottom classes for spacing typography elements without nested CSS. Prefer these over component-specific descendant selectors.</p>
+    <div class="sg-token-grid" style="grid-template-columns:1fr;">
+      <div class="sg-token"><span class="sg-token__name">.mb--xs</span><span class="sg-token__value">var(--space-xs) — 8px — col label → list spacing</span></div>
+      <div class="sg-token"><span class="sg-token__name">.mb--sm</span><span class="sg-token__value">var(--space-sm) — 16px — eyebrow → title, badge-group label → chips</span></div>
+      <div class="sg-token"><span class="sg-token__name">.mb--sm-plus</span><span class="sg-token__value">var(--space-sm-plus) — 24px</span></div>
+      <div class="sg-token"><span class="sg-token__name">.mb--md</span><span class="sg-token__value">var(--space-md) — 32px</span></div>
+    </div>
   </section>
 
   <!-- ============================================================
@@ -918,13 +916,13 @@
 &lt;/nav&gt;</pre>
     <p class="sg-note"><code>.nav.scrolled</code> adds a border and shadow — applied by JS on scroll. <code>.nav.name-visible</code> fades the wordmark in — applied by JS via IntersectionObserver on the hero name.</p>
 
-    <!-- TECHNICAL EXPERIENCE -->
-    <h2 class="sg-subheading" id="components-tech">Technical Experience</h2>
-    <p class="sg-desc">Displays grouped technology stacks as labeled chip clusters. Each group has an overline heading and a flex-wrapped chip row using <code>.badge</code> elements.</p>
+    <!-- BADGE GROUP -->
+    <h2 class="sg-subheading" id="components-badge-group">Badge Group</h2>
+    <p class="sg-desc">A labeled cluster of pill badges. Each group has an overline heading and a flex-wrapped chip row using <code>.badge</code> elements. Named by pattern, not content — reusable anywhere badges need a labeled grouping.</p>
     <div class="sg-demo">
-      <div class="tech__group">
-        <p class="text--overline" style="font-family:'Exo',sans-serif;font-size:var(--font-size-xs);letter-spacing:var(--tracking-wider);margin-bottom:var(--space-sm);">Frontend</p>
-        <div class="tech__chips">
+      <div class="badge-group">
+        <p class="text--overline mb--sm" style="font-family:'Exo',sans-serif;">Frontend</p>
+        <div class="badge-group__chips">
           <span class="badge">React</span>
           <span class="badge">TypeScript</span>
           <span class="badge">CSS</span>
@@ -932,14 +930,14 @@
         </div>
       </div>
     </div>
-    <pre class="sg-code">&lt;div class="tech__group"&gt;
-  &lt;p class="text--overline"&gt;Group Label&lt;/p&gt;
-  &lt;div class="tech__chips"&gt;
+    <pre class="sg-code">&lt;div class="badge-group"&gt;
+  &lt;p class="text--overline mb--sm"&gt;Group Label&lt;/p&gt;
+  &lt;div class="badge-group__chips"&gt;
     &lt;span class="badge"&gt;Chip&lt;/span&gt;
     &lt;span class="badge"&gt;Chip&lt;/span&gt;
   &lt;/div&gt;
 &lt;/div&gt;</pre>
-    <p class="sg-note"><code>.tech__chips</code> is <code>display: flex; flex-wrap: wrap; gap: var(--space-xs)</code>. Uses <code>.badge</code> for the individual chips. Groups are placed inside a <code>.grid--3col</code> wrapper in the page.</p>
+    <p class="sg-note"><code>.badge-group__chips</code> is <code>display: flex; flex-wrap: wrap; gap: var(--space-xs)</code>. Uses <code>.badge</code> for the individual chips. Groups are placed inside a <code>.grid--3col</code> wrapper. The <code>.mb--sm</code> on the label drives spacing without nested CSS.</p>
 
     <!-- FOOTER -->
     <h2 class="sg-subheading" id="components-footer">Footer</h2>


### PR DESCRIPTION
# Summary

- **Consolidated font family tokens** — removed `--font-display` (identical to `--font-body`); all references updated to `--font-body`
- **Reduced font size scale from 8 steps to 5**
- **Removed `.text--tag`**
- **Added `.text--col-label`** 
- **Added `mb--*` spacing utilities** (`mb--xs/sm/sm-plus/md`) 
- **Renamed tech component** - naming tied to function not content
- **Removed accordion title gradient-on-hover** 
- **Unified button lift behavior** 
- **Styleguide kept in sync** throughout 
- **Remove descendant typography selectors in the CSS**