### PR TITLE
refactor(lets-talk): update section for employed status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .claude/
 resumes/
+docs/

--- a/index.html
+++ b/index.html
@@ -731,20 +731,12 @@
             <div class="lets-talk__content">
               <p class="section__eyebrow mb--sm">Get In Touch</p>
               <h2 class="section__title" id="lets-talk-heading">
-                Interested in all this?<br />Let's talk.
+                Want to connect?<br />Let's talk.
               </h2>
               <p class="section__subtitle">
-                I'm open to several types of work:
-              </p>
-              <ul class="arrow-list section__subtitle">
-                <li>Staff or Senior Engineer roles on product-focused teams</li>
-                <li>Engineering Manager opportunities</li>
-                <li>Independent consulting on the right projects</li>
-              </ul>
-              <p class="section__subtitle">
-                Not hiring right now? That’s cool. I’m always happy to connect
-                with people thinking seriously about engineering culture, team
-                health, and how organizations actually ship.
+                I’m currently settled into a new role, but I’m always happy to
+                connect — especially around engineering culture, team health,
+                and how organizations actually ship.
               </p>
               <div class="lets-talk__actions">
                 <a href="mailto:fluckeya@gmail.com" class="btn btn--primary">


### PR DESCRIPTION
## Summary

- Updated heading from "Interested in all this? Let's talk." → "Want to connect? Let's talk."
- Removed the open-to-work bullet list (Staff/Senior Engineer, EM, consulting)
- Replaced the "not hiring? that's cool" fallback paragraph with a single honest line reflecting current status

## Why

No longer actively job-seeking. Keeping the section but shifting tone to "happy to connect, not looking."

## Test plan

- [x] Review section visually at `/#lets-talk`
- [x] Confirm heading, paragraph, and CTAs render correctly
- [x] Confirm bullet list is fully removed